### PR TITLE
feat: non-fungible traits for contracts

### DIFF
--- a/frame/contracts/src/impl_nonfungibles.rs
+++ b/frame/contracts/src/impl_nonfungibles.rs
@@ -1,0 +1,195 @@
+use super::*;
+use codec::Decode;
+use frame_support::{
+	storage::KeyPrefixIterator,
+	traits::{tokens::nonfungibles::InspectPSP34, tokens::nonfungibles::*, Get},
+	BoundedSlice,
+};
+use frame_system::Config as SystemConfig;
+use sp_runtime::{DispatchError, DispatchResult};
+use sp_std::prelude::*;
+
+
+const MINT_SELECTOR: [u8; 4] = [0x1, 0x2, 0x3, 0x4];
+const BURN_SELECTOR: [u8; 4] = [0x4, 0x3, 0x2, 0x1];
+const TRANSFER_SELECTOR: [u8; 4] = [0x5, 0x6, 0x7, 0x8];
+const OWNER_OF_SELECTOR: [u8; 4] = [0x56, 0x66, 0x7, 0x8];
+
+impl<T: Config> InspectPSP34<<T as SystemConfig>::AccountId> for Pallet<T> {
+
+	type ItemId = u32;
+	type CollectionId = T::AccountId;
+
+	fn owner(
+        who: T::AccountId,
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,    
+	) -> Option<<T as SystemConfig>::AccountId> {
+        let mut data = vec![];
+		data.extend(OWNER_OF_SELECTOR);
+		data.extend(item.encode());
+
+		Self::bare_call(
+			who.clone(),
+			collection.clone(),
+			0,
+			Weight::from_all(u64::MAX),
+			None,
+			data,
+			false,
+			Determinism::Deterministic,
+		).result.unwrap().data.decode::<Option<T::AccountId>>();
+	}
+
+	fn collection_owner(
+        who: T::AccountId,
+		_collection: &Self::CollectionId,
+	) -> Option<<T as SystemConfig>::AccountId> {
+		None
+	}
+
+	fn attribute(
+		_collection: &Self::CollectionId,
+		_item: &Self::ItemId,
+		_key: &[u8],
+	) -> Option<Vec<u8>> {
+		None
+	}
+
+	fn collection_attribute(who: T::AccountId, _collection: &Self::CollectionId, _key: &[u8]) -> Option<Vec<u8>> {
+		None
+	}
+
+	fn can_transfer(who: T::AccountId, _collection: &Self::CollectionId, _item: &Self::ItemId) -> bool {
+		true
+	}
+
+	fn typed_attribute<K: Encode, V: codec::Decode>(
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		key: &K,
+	) -> Option<V> {
+		key.using_encoded(|d| Self::attribute(collection, item, d))
+			.and_then(|v| V::decode(&mut &v[..]).ok())
+	}
+
+	fn typed_collection_attribute<K: Encode, V: Decode>(
+		who: T::AccountId,
+		collection: &Self::CollectionId,
+		key: &K,
+	) -> Option<V> {
+		key.using_encoded(|d| Self::collection_attribute(who,collection, d))
+			.and_then(|v| V::decode(&mut &v[..]).ok())
+	}
+}
+
+impl<T: Config> MutatePSP34<<T as SystemConfig>::AccountId> for Pallet<T> {
+	fn mint_into(
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		who: &T::AccountId,
+	) -> DispatchResult {
+		let mut data = vec![];  
+		data.extend(MINT_SELECTOR);
+		data.extend(who.encode());
+		data.extend(item.encode());
+
+		Self::bare_call(
+			who.clone(),
+			collection.clone(),
+			0,
+			Weight::from_all(u64::MAX),
+			None,
+			data,
+			false,
+			Determinism::Deterministic,
+		);
+		Ok(())
+	}
+
+	fn burn(
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		maybe_check_owner: &T::AccountId,
+	) -> DispatchResult {
+        let mut data = vec![];
+		data.extend(BURN_SELECTOR);
+		data.extend(item.encode());
+
+		Self::bare_call(
+			maybe_check_owner.clone(),
+			collection.clone(),
+			0,
+			Weight::from_all(u64::MAX),
+			None,
+			data,
+			false,
+			Determinism::Deterministic,
+		);
+		Ok(())
+		
+	}
+
+	fn set_attribute(
+		_collection: &Self::CollectionId,
+		_item: &Self::ItemId,
+		_key: &[u8],
+		_value: &[u8],
+	) -> frame_support::pallet_prelude::DispatchResult {
+		Err(sp_runtime::TokenError::Unsupported.into())
+	}
+
+	fn set_typed_attribute<K: Encode, V: Encode>(
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		key: &K,
+		value: &V,
+	) -> frame_support::pallet_prelude::DispatchResult {
+		key.using_encoded(|k| value.using_encoded(|v| Self::set_attribute(collection, item, k, v)))
+	}
+
+	fn set_collection_attribute(
+		_collection: &Self::CollectionId,
+		_key: &[u8],
+		_value: &[u8],
+	) -> frame_support::pallet_prelude::DispatchResult {
+		Err(sp_runtime::TokenError::Unsupported.into())
+	}
+
+	fn set_typed_collection_attribute<K: Encode, V: Encode>(
+		collection: &Self::CollectionId,
+		key: &K,
+		value: &V,
+	) -> frame_support::pallet_prelude::DispatchResult {
+		key.using_encoded(|k| {
+			value.using_encoded(|v| Self::set_collection_attribute(collection, k, v))
+		})
+	}
+}
+
+impl<T: Config> TransferPSP34<T::AccountId> for Pallet<T> {
+	fn transfer(
+        who: &T::AccountId,
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		destination: &T::AccountId,
+	) -> DispatchResult {
+        let mut data = vec![];
+		data.extend(TRANSFER_SELECTOR);
+		data.extend(destination.encode());
+		data.extend(item.encode());
+
+		Self::bare_call(
+			who.clone(),
+			collection.clone(),
+			0,
+			Weight::from_all(u64::MAX),
+			None,
+			data,
+			false,
+			Determinism::Deterministic,
+		);
+		Ok(())
+		// Self::do_transfer(*collection, *item, destination.clone(), |_, _| Ok(()))
+	}
+}

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -92,6 +92,7 @@ mod migration;
 mod schedule;
 mod storage;
 mod wasm;
+mod impl_nonfungibles;
 
 pub mod chain_extension;
 pub mod weights;

--- a/frame/support/src/traits/tokens/nonfungibles.rs
+++ b/frame/support/src/traits/tokens/nonfungibles.rs
@@ -102,6 +102,76 @@ pub trait Inspect<AccountId> {
 	}
 }
 
+
+pub trait InspectPSP34<AccountId> {
+	/// Type for identifying an item.
+	type ItemId;
+
+	/// Type for identifying a collection (an identifier for an independent collection of
+	/// items).
+	type CollectionId: From<[u8;32]>;
+
+	/// Returns the owner of `item` of `collection`, or `None` if the item doesn't exist
+	/// (or somehow has no owner).
+	fn owner(who: AccountId, collection: &Self::CollectionId, item: &Self::ItemId) -> Option<AccountId>;
+
+	/// Returns the owner of the `collection`, if there is one. For many NFTs this may not
+	/// make any sense, so users of this API should not be surprised to find a collection
+	/// results in `None` here.
+	fn collection_owner(_who: AccountId, _collection: &Self::CollectionId) -> Option<AccountId> {
+		None
+	}
+
+	/// Returns the attribute value of `item` of `collection` corresponding to `key`.
+	///
+	/// By default this is `None`; no attributes are defined.
+	fn attribute(
+		_collection: &Self::CollectionId,
+		_item: &Self::ItemId,
+		_key: &[u8],
+	) -> Option<Vec<u8>> {
+		None
+	}
+
+	/// Returns the strongly-typed attribute value of `item` of `collection` corresponding to
+	/// `key`.
+	///
+	/// By default this just attempts to use `attribute`.
+	fn typed_attribute<K: Encode, V: Decode>(
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		key: &K,
+	) -> Option<V> {
+		key.using_encoded(|d| Self::attribute(collection, item, d))
+			.and_then(|v| V::decode(&mut &v[..]).ok())
+	}
+
+	/// Returns the attribute value of `collection` corresponding to `key`.
+	///
+	/// By default this is `None`; no attributes are defined.
+	fn collection_attribute(who: AccountId,_collection: &Self::CollectionId, _key: &[u8]) -> Option<Vec<u8>> {
+		None
+	}
+
+	/// Returns the strongly-typed attribute value of `collection` corresponding to `key`.
+	///
+	/// By default this just attempts to use `collection_attribute`.
+	fn typed_collection_attribute<K: Encode, V: Decode>(
+		who: AccountId,
+		collection: &Self::CollectionId,
+		key: &K,
+	) -> Option<V> {
+		key.using_encoded(|d| Self::collection_attribute(who,collection, d))
+			.and_then(|v| V::decode(&mut &v[..]).ok())
+	}
+
+	/// Returns `true` if the `item` of `collection` may be transferred.
+	///
+	/// Default implementation is that all items are transferable.
+	fn can_transfer(who: AccountId,_collection: &Self::CollectionId, _item: &Self::ItemId) -> bool {
+		true
+	}
+}
 /// Interface for enumerating items in existence or owned by a given account over many collections
 /// of NFTs.
 pub trait InspectEnumerable<AccountId>: Inspect<AccountId> {
@@ -238,11 +308,92 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 		})
 	}
 }
+pub trait MutatePSP34<AccountId>: InspectPSP34<AccountId> {
+	/// Mint some `item` of `collection` to be owned by `who`.
+	///
+	/// By default, this is not a supported operation.
+	fn mint_into(
+		_collection: &Self::CollectionId,
+		_item: &Self::ItemId,
+		_who: &AccountId,
+	) -> DispatchResult {
+		Err(TokenError::Unsupported.into())
+	}
+
+	/// Burn some `item` of `collection`.
+	///
+	/// By default, this is not a supported operation.
+	fn burn(
+		_collection: &Self::CollectionId,
+		_item: &Self::ItemId,
+		_owner: &AccountId,
+	) -> DispatchResult {
+		Err(TokenError::Unsupported.into())
+	}
+
+	/// Set attribute `value` of `item` of `collection`'s `key`.
+	///
+	/// By default, this is not a supported operation.
+	fn set_attribute(
+		_collection: &Self::CollectionId,
+		_item: &Self::ItemId,
+		_key: &[u8],
+		_value: &[u8],
+	) -> DispatchResult {
+		Err(TokenError::Unsupported.into())
+	}
+
+	/// Attempt to set the strongly-typed attribute `value` of `item` of `collection`'s `key`.
+	///
+	/// By default this just attempts to use `set_attribute`.
+	fn set_typed_attribute<K: Encode, V: Encode>(
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		key: &K,
+		value: &V,
+	) -> DispatchResult {
+		key.using_encoded(|k| value.using_encoded(|v| Self::set_attribute(collection, item, k, v)))
+	}
+
+	/// Set attribute `value` of `collection`'s `key`.
+	///
+	/// By default, this is not a supported operation.
+	fn set_collection_attribute(
+		_collection: &Self::CollectionId,
+		_key: &[u8],
+		_value: &[u8],
+	) -> DispatchResult {
+		Err(TokenError::Unsupported.into())
+	}
+
+	/// Attempt to set the strongly-typed attribute `value` of `collection`'s `key`.
+	///
+	/// By default this just attempts to use `set_attribute`.
+	fn set_typed_collection_attribute<K: Encode, V: Encode>(
+		collection: &Self::CollectionId,
+		key: &K,
+		value: &V,
+	) -> DispatchResult {
+		key.using_encoded(|k| {
+			value.using_encoded(|v| Self::set_collection_attribute(collection, k, v))
+		})
+	}
+}
 
 /// Trait for providing a non-fungible sets of items which can only be transferred.
 pub trait Transfer<AccountId>: Inspect<AccountId> {
 	/// Transfer `item` of `collection` into `destination` account.
 	fn transfer(
+		collection: &Self::CollectionId,
+		item: &Self::ItemId,
+		destination: &AccountId,
+	) -> DispatchResult;
+}
+
+pub trait TransferPSP34<AccountId>: InspectPSP34<AccountId> {
+	/// Transfer `item` of `collection` into `destination` account.
+	fn transfer(
+		who: &AccountId,
 		collection: &Self::CollectionId,
 		item: &Self::ItemId,
 		destination: &AccountId,


### PR DESCRIPTION
Trait definitions for nonfungibles::MutatePSP34<AccountId> to make pallet_contracts compatible with PSP34MutateAdapter trait 